### PR TITLE
Shorten remote command notes for NS view

### DIFF
--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
@@ -77,7 +77,7 @@ extension TrioRemoteControl {
             carbs: carbsDecimal ?? 0,
             fat: fatDecimal,
             protein: proteinDecimal,
-            note: "Remote meal command",
+            note: "📡📲",
             enteredBy: CarbsEntry.local,
             isFPU: false,
             fpuID: fatDecimal ?? 0 > 0 || proteinDecimal ?? 0 > 0 ? UUID().uuidString : nil


### PR DESCRIPTION
- Removed "Remote meal command" text and replaced with shortened version
- Less cluttered Nightscout screen
- Selected 📡📲 (satellite to phone) for a very clear, succinct visual explanation